### PR TITLE
Ilyaz/linux arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ out/gopogh-darwin-amd64: embed-static $(SOURCE_FILES) go.mod
 out/gopogh-linux-amd64: embed-static $(SOURCE_FILES) go.mod
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
 
+out/gopogh-linux-arm64: embed-static $(SOURCE_FILES) go.mod
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+
 out/gopogh.exe: embed-static $(SOURCE_FILES) go.mod
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64  go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
 
@@ -44,7 +47,7 @@ test: build
 
 
 .PHONY: cross
-cross: out/gopogh-linux-amd64 out/gopogh-darwin-amd64 out/gopogh.exe
+cross: out/gopogh-linux-amd64 out/gopogh-linux-arm64 out/gopogh-darwin-amd64 out/gopogh.exe
 
 
 .PHONY: clean
@@ -63,3 +66,4 @@ test-in-docker:
 	rm ./testdata/docker-test/testout.json || true
 	rm ./testdata/docker-test/testout.html || true
 	docker run  -it -e NAME="${JOB_NAME} ${GITHUB_REF}" -e REPO="${GITHUB_REPOSITORY}" -e DETAILS="${GITHUB_SHA}" -v $(CURDIR)/testdata/docker-test:/data  local/gopogh ./text2html.sh
+


### PR DESCRIPTION
This PR adds a make target to build gopogh for linux/arm64 platform

```
izuyev@izuyev-macbookpro --- z/gopogh ‹ilyaz/linux_arm64› » make out/gopogh-linux-arm64
cd pkg/report && rice embed-go
CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-X github.com/medyagh/gopogh/pkg/report.Build="7d8e0d4b474c48e7dab25a1b1ef96b2680f96ead"" -a -o out/gopogh-linux-arm64 github.com/medyagh/gopogh/cmd/gopogh
izuyev@izuyev-macbookpro --- z/gopogh ‹ilyaz/linux_arm64› » 
```