### PR TITLE
add short summary to outputfile and add durations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ test: build
 	rm ./out/output2.html || true
 	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/minikube-logs.json" -out_html "./out/output.html" -out_summary out/output_summary.json -details "0c07e808219403a7241ee5a0fc6a85a897594339"
 	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/Docker_Linux.json" -out_html "./out/output2.html" -out_summary out/output2_summary.json "0c07e808219403a7241ee5a0fc6a85a897594339"
+	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/Docker_Linux.json" -out_html "./out/output2NoSummary.html"  "0c07e808219403a7241ee5a0fc6a85a897594339"
 
 
 .PHONY: cross

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ generate_json:
 test: build
 	rm ./out/output.html || true
 	rm ./out/output2.html || true
-	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/minikube-logs.json" -out "./out/output.html" -details "0c07e808219403a7241ee5a0fc6a85a897594339"
-	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/Docker_Linux.json" -out "./out/output2.html" -details "0c07e808219403a7241ee5a0fc6a85a897594339"
+	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/minikube-logs.json" -out_html "./out/output.html" -out_summary out/output_summary.json -details "0c07e808219403a7241ee5a0fc6a85a897594339"
+	.${BINARY} -name "KVM Linux" -repo "github.com/kubernetes/minikube/" -pr "6096" -in "testdata/Docker_Linux.json" -out_html "./out/output2.html" -out_summary out/output2_summary.json "0c07e808219403a7241ee5a0fc6a85a897594339"
 
 
 .PHONY: cross

--- a/cmd/gopogh/main.go
+++ b/cmd/gopogh/main.go
@@ -62,13 +62,14 @@ func main() {
 			panic(fmt.Sprintf("failed to write the html output %s: %v", *outHTMLPath, err))
 		}
 	}
-
 	j, err := c.ShortSummary()
 	if err != nil {
 		fmt.Printf("failed to convert report to json: %v", err)
 	} else {
-		if err := ioutil.WriteFile(*outSummaryPath, j, 0644); err != nil {
-			panic(fmt.Sprintf("failed to write the html output %s: %v", *outSummaryPath, err))
+		if *outSummaryPath != "" {
+			if err := ioutil.WriteFile(*outSummaryPath, j, 0644); err != nil {
+				panic(fmt.Sprintf("failed to write the html output %s: %v", *outSummaryPath, err))
+			}
 		}
 		fmt.Println(string(j))
 	}

--- a/cmd/gopogh/main.go
+++ b/cmd/gopogh/main.go
@@ -14,13 +14,15 @@ import (
 var Build string
 
 var (
-	reportName    = flag.String("name", "", "report name ")
-	reportPR      = flag.String("pr", "", "Pull request number")
-	reportDetails = flag.String("details", "", "report details (for example test args...)")
-	reportRepo    = flag.String("repo", "", "source repo")
-	inPath        = flag.String("in", "", "path to JSON input file")
-	outPath       = flag.String("out", "", "path to HTML output file")
-	version       = flag.Bool("version", false, "shows version")
+	reportName     = flag.String("name", "", "report name ")
+	reportPR       = flag.String("pr", "", "Pull request number")
+	reportDetails  = flag.String("details", "", "report details (for example test args...)")
+	reportRepo     = flag.String("repo", "", "source repo")
+	inPath         = flag.String("in", "", "path to JSON file produced by go tool test2json")
+	outPath        = flag.String("out", "", "(depricated use  -out_html instead) path to HTML output file ")
+	outHTMLPath    = flag.String("out_html", "", "path to HTML output file")
+	outSummaryPath = flag.String("out_summary", "", "path to json summary output file")
+	version        = flag.Bool("version", false, "shows version")
 )
 
 func main() {
@@ -32,7 +34,12 @@ func main() {
 	if *inPath == "" {
 		panic("must provide path to JSON input file")
 	}
-	if *outPath == "" {
+
+	if *outPath != "" {
+		*outHTMLPath = *outPath
+	}
+
+	if *outHTMLPath == "" {
 		panic("must provide path to HTML output file")
 	}
 
@@ -51,8 +58,8 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to convert report to html: %v", err)
 	} else {
-		if err := ioutil.WriteFile(*outPath, html, 0644); err != nil {
-			panic(fmt.Sprintf("failed to write the html output %s: %v", *outPath, err))
+		if err := ioutil.WriteFile(*outHTMLPath, html, 0644); err != nil {
+			panic(fmt.Sprintf("failed to write the html output %s: %v", *outHTMLPath, err))
 		}
 	}
 
@@ -60,6 +67,9 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to convert report to json: %v", err)
 	} else {
+		if err := ioutil.WriteFile(*outSummaryPath, j, 0644); err != nil {
+			panic(fmt.Sprintf("failed to write the html output %s: %v", *outSummaryPath, err))
+		}
 		fmt.Println(string(j))
 	}
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -28,26 +28,36 @@ func (c DisplayContent) ShortSummary() ([]byte, error) {
 		NumberOfSkip  int
 		FailedTests   []string
 		PassedTests   []string
+		SkippedTests  []string
+		Durations     map[string]float64
 		GopoghVersion string
 		GopoghBuild   string
 		Detail        models.ReportDetail
 	}
 	ss := shortSummary{}
+	ss.Durations = make(map[string]float64)
 	for _, t := range resultTypes {
 		if t == pass {
 			ss.NumberOfPass = len(c.Results[t])
 			for _, ti := range c.Results[t] {
 				ss.PassedTests = append(ss.PassedTests, ti.TestName)
+				ss.Durations[ti.TestName] = ti.Duration
 			}
 		}
 		if t == fail {
 			ss.NumberOfFail = len(c.Results[t])
 			for _, ti := range c.Results[t] {
 				ss.FailedTests = append(ss.FailedTests, ti.TestName)
+				ss.Durations[ti.TestName] = ti.Duration
 			}
 		}
 		if t == skip {
-			ss.NumberOfSkip = len(c.Results[t])
+			for _, ti := range c.Results[t] {
+				ss.SkippedTests = append(ss.SkippedTests, ti.TestName)
+				// not adding to the skip test durations to avoid confusion or bad data, since they will be 0seconds most-likely
+				// but if I change my mind we need to uncomment this line
+				// ss.Durations[ti.TestName] = ti.Duration
+			}
 		}
 
 	}
@@ -56,11 +66,6 @@ func (c DisplayContent) ShortSummary() ([]byte, error) {
 	ss.GopoghVersion = Version
 	ss.GopoghBuild = Build
 	return json.MarshalIndent(ss, "", "    ")
-}
-
-// JSON return the report in json
-func (c DisplayContent) JSON() ([]byte, error) {
-	return json.MarshalIndent(c, "", "    ")
 }
 
 // HTML returns html format


### PR DESCRIPTION
after this PR
-  Add a flag to write json summary to a file

```
{
    "NumberOfTests": 182,
    "NumberOfFail": 1,
    "NumberOfPass": 181,
    "NumberOfSkip": 0,
    "FailedTests": [
        "TestErrorSpam"
    ],
    "PassedTests": [
        "TestDownloadOnly/crio/v1.13.0",
        "TestDownloadOnly/crio/v1.18.3",
        "TestDownloadOnly/crio/v1.18.4-rc.0",
        "TestDownloadOnly/crio/DeleteAll",
        "TestDownloadOnly/crio/DeleteAlwaysSucceeds",
        "TestDownloadOnly/docker/v1.13.0",
        "TestDownloadOnly/docker/v1.18.3",
        "TestDownloadOnly/docker/v1.18.4-rc.0",
        "TestDownloadOnly/docker/DeleteAll",
        "TestDownloadOnly/docker/DeleteAlwaysSucceeds",
        "TestDownloadOnly/containerd/v1.13.0",
        "TestDownloadOnly/containerd/v1.18.3",
        "TestDownloadOnly/containerd/v1.18.4-rc.0",
        "TestDownloadOnly/containerd/DeleteAll",
        "TestDownloadOnly/containerd/DeleteAlwaysSucceeds",
        "TestDownloadOnlyKic",
        "TestOffline/group/docker",
        "TestOffline/group/crio",
        "TestOffline/group/containerd",
        "TestAddons/parallel/Registry",
        "TestAddons/parallel/Ingress",
        "TestAddons/parallel/MetricsServer",
        "TestAddons/parallel/HelmTiller",
        "TestCertOptions",
        "TestDockerFlags",
        "TestForceSystemdFlag",
        "TestForceSystemdEnv",
        "TestFunctional/serial/CopySyncFile",
        "TestFunctional/serial/StartWithProxy",
        "TestFunctional/serial/SoftStart",
        "TestFunctional/serial/KubeContext",
        "TestFunctional/serial/KubectlGetPods",
        "TestFunctional/serial/CacheCmd/cache/add",
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc",
        "TestFunctional/serial/CacheCmd/cache/list",
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node",
        "TestFunctional/serial/CacheCmd/cache/cache_reload",
        "TestFunctional/serial/CacheCmd/cache/delete",
        "TestFunctional/serial/MinikubeKubectlCmd",
        "TestMultiNode/serial/FreshStart2Nodes",
        "TestMultiNode/serial/AddNode",
        "TestMultiNode/serial/StopNode",
        "TestMultiNode/serial/StartAfterStop",
        "TestMultiNode/serial/DeleteNode",
        "TestMultiNode/serial/StopMultiNode",
        "TestMultiNode/serial/RestartMultiNode",
        "TestPreload",
        "TestRunningBinaryUpgrade",
        "TestStoppedBinaryUpgrade",
        "TestKubernetesUpgrade",
        "TestMissingContainerUpgrade",
        "TestPause/serial/Start",
        "TestFunctional/parallel/ComponentHealth",
        "TestFunctional/parallel/ConfigCmd",
        "TestFunctional/parallel/DashboardCmd",
        "TestFunctional/parallel/DryRun",
        "TestFunctional/parallel/StatusCmd",
        "TestFunctional/parallel/LogsCmd",
        "TestFunctional/parallel/MountCmd",
        "TestFunctional/parallel/ServiceCmd",
        "TestFunctional/parallel/AddonsCmd",
        "TestFunctional/parallel/PersistentVolumeClaim",
        "TestFunctional/parallel/SSHCmd",
        "TestFunctional/parallel/MySQL",
        "TestFunctional/parallel/FileSync",
        "TestFunctional/parallel/CertSync",
        "TestFunctional/parallel/UpdateContextCmd",
        "TestFunctional/parallel/DockerEnv",
        "TestFunctional/parallel/NodeLabels",
        "TestPause/serial/SecondStartNoReconfiguration",
        "TestPause/serial/Pause",
        "TestPause/serial/Unpause",
        "TestPause/serial/PauseAgain",
        "TestPause/serial/DeletePaused",
        "TestPause/serial/VerifyDeletedResources",
        "TestNetworkPlugins/group/auto/Start",
        "TestNetworkPlugins/group/false/Start",
        "TestNetworkPlugins/group/cilium/Start",
        "TestNetworkPlugins/group/auto/KubeletFlags",
        "TestNetworkPlugins/group/auto/NetCatPod",
        "TestNetworkPlugins/group/auto/DNS",
        "TestNetworkPlugins/group/auto/Localhost",
        "TestNetworkPlugins/group/auto/HairPin",
        "TestNetworkPlugins/group/false/KubeletFlags",
        "TestNetworkPlugins/group/false/NetCatPod",
        "TestNetworkPlugins/group/calico/Start",
        "TestNetworkPlugins/group/false/DNS",
        "TestNetworkPlugins/group/false/Localhost",
        "TestNetworkPlugins/group/false/HairPin",
        "TestNetworkPlugins/group/custom-weave/Start",
        "TestNetworkPlugins/group/cilium/ControllerPod",
        "TestNetworkPlugins/group/cilium/KubeletFlags",
        "TestNetworkPlugins/group/cilium/NetCatPod",
        "TestNetworkPlugins/group/custom-weave/KubeletFlags",
        "TestNetworkPlugins/group/custom-weave/NetCatPod",
        "TestNetworkPlugins/group/cilium/DNS",
        "TestNetworkPlugins/group/cilium/Localhost",
        "TestNetworkPlugins/group/cilium/HairPin",
        "TestNetworkPlugins/group/enable-default-cni/Start",
        "TestNetworkPlugins/group/calico/ControllerPod",
        "TestNetworkPlugins/group/calico/KubeletFlags",
        "TestNetworkPlugins/group/calico/NetCatPod",
        "TestNetworkPlugins/group/kindnet/Start",
        "TestNetworkPlugins/group/bridge/Start",
        "TestNetworkPlugins/group/calico/DNS",
        "TestNetworkPlugins/group/calico/Localhost",
        "TestNetworkPlugins/group/calico/HairPin",
        "TestNetworkPlugins/group/kubenet/Start",
        "TestNetworkPlugins/group/enable-default-cni/KubeletFlags",
        "TestNetworkPlugins/group/enable-default-cni/NetCatPod",
        "TestNetworkPlugins/group/enable-default-cni/DNS",
        "TestNetworkPlugins/group/enable-default-cni/Localhost",
        "TestNetworkPlugins/group/enable-default-cni/HairPin",
        "TestNetworkPlugins/group/kubenet/KubeletFlags",
        "TestNetworkPlugins/group/kubenet/NetCatPod",
        "TestNetworkPlugins/group/bridge/KubeletFlags",
        "TestNetworkPlugins/group/bridge/NetCatPod",
        "TestNetworkPlugins/group/kindnet/ControllerPod",
        "TestNetworkPlugins/group/kubenet/DNS",
        "TestNetworkPlugins/group/kubenet/Localhost",
        "TestNetworkPlugins/group/kubenet/HairPin",
        "TestNetworkPlugins/group/bridge/DNS",
        "TestNetworkPlugins/group/bridge/Localhost",
        "TestNetworkPlugins/group/bridge/HairPin",
        "TestFunctional/parallel/TunnelCmd/serial/StartTunnel",
        "TestNetworkPlugins/group/kindnet/KubeletFlags",
        "TestNetworkPlugins/group/kindnet/NetCatPod",
        "TestFunctional/parallel/TunnelCmd/serial/WaitService/IngressIP",
        "TestFunctional/parallel/TunnelCmd/serial/AccessDirect",
        "TestFunctional/parallel/TunnelCmd/serial/DeleteTunnel",
        "TestFunctional/parallel/ProfileCmd/profile_not_create",
        "TestFunctional/parallel/ProfileCmd/profile_list",
        "TestFunctional/parallel/ProfileCmd/profile_json_output",
        "TestNetworkPlugins/group/kindnet/DNS",
        "TestNetworkPlugins/group/kindnet/Localhost",
        "TestNetworkPlugins/group/kindnet/HairPin",
        "TestStartStop/group/old-k8s-version/serial/FirstStart",
        "TestStartStop/group/crio/serial/FirstStart",
        "TestStartStop/group/embed-certs/serial/FirstStart",
        "TestStartStop/group/containerd/serial/FirstStart",
        "TestStartStop/group/embed-certs/serial/DeployApp",
        "TestStartStop/group/embed-certs/serial/Stop",
        "TestStartStop/group/embed-certs/serial/EnableAddonAfterStop",
        "TestStartStop/group/embed-certs/serial/SecondStart",
        "TestStartStop/group/containerd/serial/DeployApp",
        "TestStartStop/group/embed-certs/serial/UserAppExistsAfterStop",
        "TestStartStop/group/containerd/serial/Stop",
        "TestStartStop/group/embed-certs/serial/AddonExistsAfterStop",
        "TestStartStop/group/embed-certs/serial/VerifyKubernetesImages",
        "TestStartStop/group/embed-certs/serial/Pause",
        "TestStartStop/group/newest-cni/serial/FirstStart",
        "TestStartStop/group/containerd/serial/EnableAddonAfterStop",
        "TestStartStop/group/old-k8s-version/serial/DeployApp",
        "TestStartStop/group/containerd/serial/SecondStart",
        "TestStartStop/group/old-k8s-version/serial/Stop",
        "TestStartStop/group/old-k8s-version/serial/EnableAddonAfterStop",
        "TestStartStop/group/old-k8s-version/serial/SecondStart",
        "TestStartStop/group/newest-cni/serial/DeployApp",
        "TestStartStop/group/newest-cni/serial/Stop",
        "TestStartStop/group/newest-cni/serial/EnableAddonAfterStop",
        "TestStartStop/group/newest-cni/serial/SecondStart",
        "TestStartStop/group/old-k8s-version/serial/UserAppExistsAfterStop",
        "TestStartStop/group/crio/serial/DeployApp",
        "TestStartStop/group/old-k8s-version/serial/AddonExistsAfterStop",
        "TestStartStop/group/crio/serial/Stop",
        "TestStartStop/group/old-k8s-version/serial/VerifyKubernetesImages",
        "TestStartStop/group/old-k8s-version/serial/Pause",
        "TestStartStop/group/newest-cni/serial/UserAppExistsAfterStop",
        "TestStartStop/group/newest-cni/serial/AddonExistsAfterStop",
        "TestStartStop/group/newest-cni/serial/VerifyKubernetesImages",
        "TestStartStop/group/newest-cni/serial/Pause",
        "TestStartStop/group/crio/serial/EnableAddonAfterStop",
        "TestStartStop/group/crio/serial/SecondStart",
        "TestStartStop/group/containerd/serial/UserAppExistsAfterStop",
        "TestStartStop/group/containerd/serial/AddonExistsAfterStop",
        "TestStartStop/group/containerd/serial/VerifyKubernetesImages",
        "TestStartStop/group/containerd/serial/Pause",
        "TestStartStop/group/crio/serial/UserAppExistsAfterStop",
        "TestStartStop/group/crio/serial/AddonExistsAfterStop",
        "TestStartStop/group/crio/serial/VerifyKubernetesImages",
        "TestStartStop/group/crio/serial/Pause"
    ],
    "SkippedTests": [
        "TestAddons/parallel/Olm",
        "TestHyperKitDriverInstallOrUpdate",
        "TestGvisorAddon",
        "TestJSONOutput",
        "TestChangeNoneUser",
        "TestNetworkPlugins/group/flannel",
        "TestFunctional/parallel/TunnelCmd/serial/DNSResolutionByDig",
        "TestFunctional/parallel/TunnelCmd/serial/DNSResolutionByDscacheutil",
        "TestFunctional/parallel/TunnelCmd/serial/AccessThroughDNS"
    ],
    "Durations": {
        "TestAddons/parallel/HelmTiller": 9.06,
        "TestAddons/parallel/Ingress": 21.36,
        "TestAddons/parallel/MetricsServer": 51.11,
        "TestAddons/parallel/Registry": 14.62,
        "TestCertOptions": 52.06,
        "TestDockerFlags": 56.65,
        "TestDownloadOnly/containerd/DeleteAll": 2.97,
        "TestDownloadOnly/containerd/DeleteAlwaysSucceeds": 0.23,
        "TestDownloadOnly/containerd/v1.13.0": 11.83,
        "TestDownloadOnly/containerd/v1.18.3": 9.96,
        "TestDownloadOnly/containerd/v1.18.4-rc.0": 17.29,
        "TestDownloadOnly/crio/DeleteAll": 0.4,
        "TestDownloadOnly/crio/DeleteAlwaysSucceeds": 1.26,
        "TestDownloadOnly/crio/v1.13.0": 6.44,
        "TestDownloadOnly/crio/v1.18.3": 6.5,
        "TestDownloadOnly/crio/v1.18.4-rc.0": 6.42,
        "TestDownloadOnly/docker/DeleteAll": 11.59,
        "TestDownloadOnly/docker/DeleteAlwaysSucceeds": 0.22,
        "TestDownloadOnly/docker/v1.13.0": 5.69,
        "TestDownloadOnly/docker/v1.18.3": 5.7,
        "TestDownloadOnly/docker/v1.18.4-rc.0": 14.03,
        "TestDownloadOnlyKic": 10.3,
        "TestErrorSpam": 70.9,
        "TestForceSystemdEnv": 69.52,
        "TestForceSystemdFlag": 74.98,
        "TestFunctional/parallel/AddonsCmd": 0.15,
        "TestFunctional/parallel/CertSync": 1.2,
        "TestFunctional/parallel/ComponentHealth": 0.34,
        "TestFunctional/parallel/ConfigCmd": 0.33,
        "TestFunctional/parallel/DashboardCmd": 5.23,
        "TestFunctional/parallel/DockerEnv": 1.29,
        "TestFunctional/parallel/DryRun": 0.61,
        "TestFunctional/parallel/FileSync": 0.41,
        "TestFunctional/parallel/LogsCmd": 2.38,
        "TestFunctional/parallel/MountCmd": 6.43,
        "TestFunctional/parallel/MySQL": 23.42,
        "TestFunctional/parallel/NodeLabels": 0.1,
        "TestFunctional/parallel/PersistentVolumeClaim": 5.33,
        "TestFunctional/parallel/ProfileCmd/profile_json_output": 0.23,
        "TestFunctional/parallel/ProfileCmd/profile_list": 0.23,
        "TestFunctional/parallel/ProfileCmd/profile_not_create": 0.34,
        "TestFunctional/parallel/SSHCmd": 0.66,
        "TestFunctional/parallel/ServiceCmd": 18.54,
        "TestFunctional/parallel/StatusCmd": 1.38,
        "TestFunctional/parallel/TunnelCmd/serial/AccessDirect": 0,
        "TestFunctional/parallel/TunnelCmd/serial/DeleteTunnel": 0.11,
        "TestFunctional/parallel/TunnelCmd/serial/StartTunnel": 0,
        "TestFunctional/parallel/TunnelCmd/serial/WaitService/IngressIP": 0.08,
        "TestFunctional/parallel/UpdateContextCmd": 0.14,
        "TestFunctional/serial/CacheCmd/cache/add": 4.14,
        "TestFunctional/serial/CacheCmd/cache/cache_reload": 1.66,
        "TestFunctional/serial/CacheCmd/cache/delete": 0.1,
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc": 0.05,
        "TestFunctional/serial/CacheCmd/cache/list": 0.05,
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node": 0.3,
        "TestFunctional/serial/CopySyncFile": 0,
        "TestFunctional/serial/KubeContext": 0.05,
        "TestFunctional/serial/KubectlGetPods": 0.28,
        "TestFunctional/serial/MinikubeKubectlCmd": 0.35,
        "TestFunctional/serial/SoftStart": 4.72,
        "TestFunctional/serial/StartWithProxy": 48.8,
        "TestKubernetesUpgrade": 417.06,
        "TestMissingContainerUpgrade": 176.54,
        "TestMultiNode/serial/AddNode": 35.93,
        "TestMultiNode/serial/DeleteNode": 6.2,
        "TestMultiNode/serial/FreshStart2Nodes": 63.91,
        "TestMultiNode/serial/RestartMultiNode": 162.29,
        "TestMultiNode/serial/StartAfterStop": 72,
        "TestMultiNode/serial/StopMultiNode": 7.68,
        "TestMultiNode/serial/StopNode": 2.68,
        "TestNetworkPlugins/group/auto/DNS": 0.22,
        "TestNetworkPlugins/group/auto/HairPin": 5.24,
        "TestNetworkPlugins/group/auto/KubeletFlags": 0.33,
        "TestNetworkPlugins/group/auto/Localhost": 0.22,
        "TestNetworkPlugins/group/auto/NetCatPod": 9.3,
        "TestNetworkPlugins/group/auto/Start": 60.64,
        "TestNetworkPlugins/group/bridge/DNS": 0.26,
        "TestNetworkPlugins/group/bridge/HairPin": 0.21,
        "TestNetworkPlugins/group/bridge/KubeletFlags": 0.4,
        "TestNetworkPlugins/group/bridge/Localhost": 0.24,
        "TestNetworkPlugins/group/bridge/NetCatPod": 10.44,
        "TestNetworkPlugins/group/bridge/Start": 91.27,
        "TestNetworkPlugins/group/calico/ControllerPod": 5.02,
        "TestNetworkPlugins/group/calico/DNS": 0.26,
        "TestNetworkPlugins/group/calico/HairPin": 0.25,
        "TestNetworkPlugins/group/calico/KubeletFlags": 0.41,
        "TestNetworkPlugins/group/calico/Localhost": 0.25,
        "TestNetworkPlugins/group/calico/NetCatPod": 11.42,
        "TestNetworkPlugins/group/calico/Start": 106.71,
        "TestNetworkPlugins/group/cilium/ControllerPod": 5.02,
        "TestNetworkPlugins/group/cilium/DNS": 0.23,
        "TestNetworkPlugins/group/cilium/HairPin": 0.25,
        "TestNetworkPlugins/group/cilium/KubeletFlags": 0.36,
        "TestNetworkPlugins/group/cilium/Localhost": 0.23,
        "TestNetworkPlugins/group/cilium/NetCatPod": 12.69,
        "TestNetworkPlugins/group/cilium/Start": 102.97,
        "TestNetworkPlugins/group/custom-weave/KubeletFlags": 0.34,
        "TestNetworkPlugins/group/custom-weave/NetCatPod": 10.31,
        "TestNetworkPlugins/group/custom-weave/Start": 82.55,
        "TestNetworkPlugins/group/enable-default-cni/DNS": 7.29,
        "TestNetworkPlugins/group/enable-default-cni/HairPin": 0.26,
        "TestNetworkPlugins/group/enable-default-cni/KubeletFlags": 0.38,
        "TestNetworkPlugins/group/enable-default-cni/Localhost": 0.24,
        "TestNetworkPlugins/group/enable-default-cni/NetCatPod": 12.39,
        "TestNetworkPlugins/group/enable-default-cni/Start": 75.91,
        "TestNetworkPlugins/group/false/DNS": 0.26,
        "TestNetworkPlugins/group/false/HairPin": 5.25,
        "TestNetworkPlugins/group/false/KubeletFlags": 0.33,
        "TestNetworkPlugins/group/false/Localhost": 0.29,
        "TestNetworkPlugins/group/false/NetCatPod": 11.5,
        "TestNetworkPlugins/group/false/Start": 72.88,
        "TestNetworkPlugins/group/kindnet/ControllerPod": 5.02,
        "TestNetworkPlugins/group/kindnet/DNS": 0.26,
        "TestNetworkPlugins/group/kindnet/HairPin": 0.24,
        "TestNetworkPlugins/group/kindnet/KubeletFlags": 0.32,
        "TestNetworkPlugins/group/kindnet/Localhost": 0.22,
        "TestNetworkPlugins/group/kindnet/NetCatPod": 11.58,
        "TestNetworkPlugins/group/kindnet/Start": 104.53,
        "TestNetworkPlugins/group/kubenet/DNS": 0.22,
        "TestNetworkPlugins/group/kubenet/HairPin": 0.22,
        "TestNetworkPlugins/group/kubenet/KubeletFlags": 0.35,
        "TestNetworkPlugins/group/kubenet/Localhost": 0.22,
        "TestNetworkPlugins/group/kubenet/NetCatPod": 9.33,
        "TestNetworkPlugins/group/kubenet/Start": 79.54,
        "TestOffline/group/containerd": 130.16,
        "TestOffline/group/crio": 107.14,
        "TestOffline/group/docker": 79.81,
        "TestPause/serial/DeletePaused": 2.91,
        "TestPause/serial/Pause": 0.7,
        "TestPause/serial/PauseAgain": 0.89,
        "TestPause/serial/SecondStartNoReconfiguration": 14.74,
        "TestPause/serial/Start": 106.71,
        "TestPause/serial/Unpause": 0.61,
        "TestPause/serial/VerifyDeletedResources": 0.43,
        "TestPreload": 133.64,
        "TestRunningBinaryUpgrade": 172.39,
        "TestStartStop/group/containerd/serial/AddonExistsAfterStop": 5.01,
        "TestStartStop/group/containerd/serial/DeployApp": 8.68,
        "TestStartStop/group/containerd/serial/EnableAddonAfterStop": 1.23,
        "TestStartStop/group/containerd/serial/FirstStart": 118.98,
        "TestStartStop/group/containerd/serial/Pause": 2.74,
        "TestStartStop/group/containerd/serial/SecondStart": 94.32,
        "TestStartStop/group/containerd/serial/Stop": 21.16,
        "TestStartStop/group/containerd/serial/UserAppExistsAfterStop": 5.02,
        "TestStartStop/group/containerd/serial/VerifyKubernetesImages": 0.32,
        "TestStartStop/group/crio/serial/AddonExistsAfterStop": 5.01,
        "TestStartStop/group/crio/serial/DeployApp": 8.68,
        "TestStartStop/group/crio/serial/EnableAddonAfterStop": 0.21,
        "TestStartStop/group/crio/serial/FirstStart": 213.8,
        "TestStartStop/group/crio/serial/Pause": 2.77,
        "TestStartStop/group/crio/serial/SecondStart": 55.3,
        "TestStartStop/group/crio/serial/Stop": 20.94,
        "TestStartStop/group/crio/serial/UserAppExistsAfterStop": 36.02,
        "TestStartStop/group/crio/serial/VerifyKubernetesImages": 0.31,
        "TestStartStop/group/embed-certs/serial/AddonExistsAfterStop": 5.02,
        "TestStartStop/group/embed-certs/serial/DeployApp": 8.84,
        "TestStartStop/group/embed-certs/serial/EnableAddonAfterStop": 0.22,
        "TestStartStop/group/embed-certs/serial/FirstStart": 88.99,
        "TestStartStop/group/embed-certs/serial/Pause": 2.89,
        "TestStartStop/group/embed-certs/serial/SecondStart": 20.72,
        "TestStartStop/group/embed-certs/serial/Stop": 11.22,
        "TestStartStop/group/embed-certs/serial/UserAppExistsAfterStop": 10.69,
        "TestStartStop/group/embed-certs/serial/VerifyKubernetesImages": 0.35,
        "TestStartStop/group/newest-cni/serial/AddonExistsAfterStop": 0,
        "TestStartStop/group/newest-cni/serial/DeployApp": 0,
        "TestStartStop/group/newest-cni/serial/EnableAddonAfterStop": 0.28,
        "TestStartStop/group/newest-cni/serial/FirstStart": 50.34,
        "TestStartStop/group/newest-cni/serial/Pause": 3.56,
        "TestStartStop/group/newest-cni/serial/SecondStart": 20,
        "TestStartStop/group/newest-cni/serial/Stop": 1.72,
        "TestStartStop/group/newest-cni/serial/UserAppExistsAfterStop": 0,
        "TestStartStop/group/newest-cni/serial/VerifyKubernetesImages": 0.38,
        "TestStartStop/group/old-k8s-version/serial/AddonExistsAfterStop": 5.01,
        "TestStartStop/group/old-k8s-version/serial/DeployApp": 8.51,
        "TestStartStop/group/old-k8s-version/serial/EnableAddonAfterStop": 0.28,
        "TestStartStop/group/old-k8s-version/serial/FirstStart": 159.73,
        "TestStartStop/group/old-k8s-version/serial/Pause": 3.35,
        "TestStartStop/group/old-k8s-version/serial/SecondStart": 30.47,
        "TestStartStop/group/old-k8s-version/serial/Stop": 11.25,
        "TestStartStop/group/old-k8s-version/serial/UserAppExistsAfterStop": 12.02,
        "TestStartStop/group/old-k8s-version/serial/VerifyKubernetesImages": 0.37,
        "TestStoppedBinaryUpgrade": 231.06
    },
    "GopoghVersion": "v0.4.0-1-g77c4d01",
    "GopoghBuild": "77c4d01034fd44418b5ba28dcde08abb87762918-dirty",
    "Detail": {
        "Name": "KVM Linux",
        "Details": "",
        "PR": "6096",
        "RepoName": "github.com/kubernetes/minikube/"
    }
}
```
