### PR TITLE
do not hide parent test that failed whereas all child tests passed

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -68,11 +68,26 @@ func ProcessEvents(evs []models.TestEvent) []models.TestGroup {
 	// Hide ancestors
 	for k, v := range gm {
 		for k2 := range gm {
-			if strings.HasPrefix(k2, fmt.Sprintf("%s/", k)) {
+			if strings.HasPrefix(k2, fmt.Sprintf("%s/", k)) && !veto(v, groups) {
 				groups[v].Hidden = true
 			}
 		}
 	}
 
 	return groups
+}
+
+// veto returns true is all child events pass, but parent event with pid fail.
+// All other combinations will return false.
+func veto(pid int, groups []models.TestGroup) bool {
+	parent := groups[pid]
+	if parent.Status != "fail" {
+		return false
+	}
+	for _, child := range groups {
+		if strings.HasPrefix(child.TestName, fmt.Sprintf("%s/", parent.TestName)) && child.Status != "pass" {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
fixes: #23 

## example

### before (as given in issue description)
https://storage.googleapis.com/minikube-builds/logs/10463/4001c0a/Docker_Linux.txt
https://storage.googleapis.com/minikube-builds/logs/10463/4001c0a/Docker_Linux.html

### after
https://gist.github.com/prezha/cba54e998ea6f6129038e029ca3147d6#file-docker_linux-html