### PR TITLE
fix build rule for linux/arm64 binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ out/gopogh-linux-arm: embed-static $(SOURCE_FILES) go.mod
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
 
 out/gopogh-linux-arm64: embed-static $(SOURCE_FILES) go.mod
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
 
 
 out/gopogh.exe: embed-static $(SOURCE_FILES) go.mod


### PR DESCRIPTION
This PR fixes the rule for `out/gopogh-linux-arm64`
before:
```
➜  gopogh git:(master) file out/gopogh-linux-arm64 
out/gopogh-linux-arm64: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=E8ZJsdVs6sRieZBiGhZC/axvImvBL8rj0G2w4lrTx/_baqjV0_ynDPvUsCbgR7/jjeua3SyPU7ggAtgrJby, not stripped
```
after:
```
➜  gopogh git:(fix_arm64_build) file out/gopogh-linux-arm64 
out/gopogh-linux-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=DDKQZ_PlpMClafa1_TW1/Be_el6ObYDHRURxmbjjN/Hw8_AlJ-ngyzhd3lPAGK/60pUH1mB6EbGNC3ER0zF, not stripped
```