### PR TITLE
Add total duration field to summary.

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -63,6 +63,9 @@ func ProcessEvents(evs []models.TestEvent) []models.TestGroup {
 		e.Output = strings.Trim(e.Output, " ")
 		groups[index].Events = append(groups[index].Events, e)
 		groups[index].Status = e.Action
+		if e.Time.After(groups[index].End) {
+			groups[index].End = e.Time
+		}
 	}
 
 	// Hide ancestors


### PR DESCRIPTION
fixes #32.

Example summary:
```
... More stuff ...
        "TestStartStop/group/no-preload/serial/FirstStart": 98.81,
        "TestStartStop/group/no-preload/serial/Pause": 2.88,
        "TestStartStop/group/no-preload/serial/SecondStart": 343.75,
        "TestStartStop/group/no-preload/serial/Stop": 11.21,
        "TestStartStop/group/no-preload/serial/UserAppExistsAfterStop": 10.02,
        "TestStartStop/group/no-preload/serial/VerifyKubernetesImages": 0.32,
        "TestStartStop/group/old-k8s-version/serial/AddonExistsAfterStop": 5.23,
        "TestStartStop/group/old-k8s-version/serial/DeployApp": 9.41,
        "TestStartStop/group/old-k8s-version/serial/EnableAddonAfterStop": 0.19,
        "TestStartStop/group/old-k8s-version/serial/EnableAddonWhileActive": 1.49,
        "TestStartStop/group/old-k8s-version/serial/FirstStart": 139.87,
        "TestStartStop/group/old-k8s-version/serial/Pause": 2.86,
        "TestStartStop/group/old-k8s-version/serial/SecondStart": 426.49,
        "TestStartStop/group/old-k8s-version/serial/Stop": 11.24,
        "TestStartStop/group/old-k8s-version/serial/UserAppExistsAfterStop": 5.01,
        "TestStartStop/group/old-k8s-version/serial/VerifyKubernetesImages": 0.33,
        "TestStoppedBinaryUpgrade/MinikubeLogs": 1.61
    },
    "TotalDuration": 2302.69,
    "GopoghVersion": "v0.8.0-1-g2653d49",
    "GopoghBuild": "2653d49b33e826c45ce2bcd8ac5e0e59237ce461-dirty",
    "Detail": {
        "Name": "Docker_Linux",
        "Details": "abc1234:2021-07-23:-1",
        "PR": "1337",
        "RepoName": "github.com/kubernetes/minikube/"
    }
}
```

Also confirmed that the TotalDuration of 2302s equals the reported time in the logs of 38m