### PR TITLE
Fix cursor not being pointer

### DIFF
--- a/pkg/templates/report3.css
+++ b/pkg/templates/report3.css
@@ -8490,7 +8490,13 @@ th {
     cursor: pointer;
 }
 
-button {
+button,
+.close,
+.closebutton,
+.minimize,
+.minimizebutton,
+.zoom,
+.zoombutton {
     cursor: pointer;
 }
 

--- a/pkg/templates/report3.css
+++ b/pkg/templates/report3.css
@@ -8487,6 +8487,7 @@ th {
     background-color: black;
     color: white;
     font-weight: bolder;
+    cursor: pointer;
 }
 
 {{end}}

--- a/pkg/templates/report3.css
+++ b/pkg/templates/report3.css
@@ -8490,4 +8490,8 @@ th {
     cursor: pointer;
 }
 
+button {
+    cursor: pointer;
+}
+
 {{end}}


### PR DESCRIPTION
Currently, hovering over the table header is just a normal cursor icon and doesn't help the user know that it's clickable. Make the cursor change to pointer when hovering over the table header to give a clue.

Made hovering over the "Copy Logs to Clipboard" and "Open in New Window" buttons use pointer cursor.

Also made hovering over the exit, minimize, and zoom buttons on the test windows use pointer cursor.