### PR TITLE
-out_html and -out_summary: create directory if not already present

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Example test logs: [before](https://storage.googleapis.com/minikube-builds/logs/
 - run gopogh on it
 
 ```
-gopogh -in ./your-test-log.json -out_html ./report/testout.html -out_summary ./your-test-summary.sjon TEST_NAME TEST_PR_NUMBER -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}")  
+TEST_PR_NUMBER=1313
+TEST_NAME="KVM Linux"
+GITHUB_REPOSITORY="github.com/kubernetes/minikube/"
+GITHUB_SHA=1234567890
+gopogh -in ./your-test-log.json -out_html ./report/testout.html -out_summary ./your-test-summary.json -name "${TEST_NAME}" -pr "${TEST_PR_NUMBER}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}" 
 ```
 
 

--- a/cmd/gopogh/main.go
+++ b/cmd/gopogh/main.go
@@ -60,7 +60,8 @@ func main() {
 		fmt.Printf("failed to convert report to html: %v", err)
 	} else {
 		if err := os.MkdirAll(filepath.Dir(*outHTMLPath), 0755); err != nil {
-			panic(fmt.Sprintf("failed to create directory: %v", err))
+			fmt.Printf("failed to create directory: %v", err)
+			os.Exit(1)
 		}
 		if err := os.WriteFile(*outHTMLPath, html, 0644); err != nil {
 			panic(fmt.Sprintf("failed to write the html output %s: %v", *outHTMLPath, err))
@@ -72,7 +73,8 @@ func main() {
 	} else {
 		if *outSummaryPath != "" {
 			if err := os.MkdirAll(filepath.Dir(*outSummaryPath), 0755); err != nil {
-				panic(fmt.Sprintf("failed to create directory: %v", err))
+				fmt.Printf("failed to create directory: %v", err)
+				os.Exit(1)
 			}
 			if err := os.WriteFile(*outSummaryPath, j, 0644); err != nil {
 				panic(fmt.Sprintf("failed to write the html output %s: %v", *outSummaryPath, err))

--- a/cmd/gopogh/main.go
+++ b/cmd/gopogh/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/medyagh/gopogh/pkg/models"
 	"github.com/medyagh/gopogh/pkg/parser"
@@ -58,6 +59,9 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to convert report to html: %v", err)
 	} else {
+		if err := os.MkdirAll(filepath.Dir(*outHTMLPath), 0755); err != nil {
+			panic(fmt.Sprintf("failed to create directory: %v", err))
+		}
 		if err := os.WriteFile(*outHTMLPath, html, 0644); err != nil {
 			panic(fmt.Sprintf("failed to write the html output %s: %v", *outHTMLPath, err))
 		}
@@ -67,6 +71,9 @@ func main() {
 		fmt.Printf("failed to convert report to json: %v", err)
 	} else {
 		if *outSummaryPath != "" {
+			if err := os.MkdirAll(filepath.Dir(*outSummaryPath), 0755); err != nil {
+				panic(fmt.Sprintf("failed to create directory: %v", err))
+			}
 			if err := os.WriteFile(*outSummaryPath, j, 0644); err != nil {
 				panic(fmt.Sprintf("failed to write the html output %s: %v", *outSummaryPath, err))
 			}


### PR DESCRIPTION
## Before: 
```
$ TEST_PR_NUMBER=1313
TEST_NAME="KVM Linux"
GITHUB_REPOSITORY="github.com/kubernetes/minikube/"
GITHUB_SHA=1234567890
./out/gopogh -in ./testdata/minikube-logs.json -out_html ./report/testout.html -out_summary ./report/test2/your-test-summary.json -name "${TEST_NAME}" -pr "${TEST_PR_NUMBER}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}" 
panic: failed to write the html output ./report/testout.html: open ./report/testout.html: no such file or directory

goroutine 1 [running]:
main.main()
        /usr/local/google/home/judahn/gopogh/cmd/gopogh/main.go:62 +0x65b
```

## After:
```
$ TEST_PR_NUMBER=1313
TEST_NAME="KVM Linux"
GITHUB_REPOSITORY="github.com/kubernetes/minikube/"
GITHUB_SHA=1234567890
./out/gopogh -in ./testdata/minikube-logs.json -out_html ./report/testout.html -out_summary ./report/test2/your-test-summary.json -name "${TEST_NAME}" -pr "${TEST_PR_NUMBER}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}" 
{
    "NumberOfTests": 44,
    "NumberOfFail": 23,
    "NumberOfPass": 19,
    "NumberOfSkip": 2,
    "FailedTests": [
        "TestOffline/group/docker",
        "TestOffline/group/crio",
        "TestOffline/group/containerd",
        "TestAddons",
        "TestFunctional/serial/StartWithProxy",
        "TestFunctional/serial/KubectlGetPods",
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node",
        "TestFunctional/serial/CacheCmd/cache/cache_reload",
        "TestGvisorAddon",
        "TestVersionUpgrade",
        "TestStartStop/group/newest-cni",
        "TestStartStop/group/containerd",
        "TestFunctional/parallel/AddonManager",
        "TestFunctional/parallel/ComponentHealth",
        "TestFunctional/parallel/DashboardCmd",
        "TestFunctional/parallel/DNS",
        "TestFunctional/parallel/StatusCmd",
        "TestFunctional/parallel/LogsCmd",
        "TestFunctional/parallel/MountCmd",
        "TestFunctional/parallel/ServiceCmd",
        "TestFunctional/parallel/PersistentVolumeClaim",
        "TestFunctional/parallel/TunnelCmd",
        "TestFunctional/parallel/MySQL"
    ],
    "PassedTests": [
        "TestDownloadOnly/group/v1.11.10",
        "TestDownloadOnly/group/v1.17.0",
        "TestDownloadOnly/group/v1.17.0#01",
        "TestDownloadOnly/group/ExpectedDefaultDriver",
        "TestDownloadOnly/group/DeleteAll",
        "TestDownloadOnly/group/DeleteAlwaysSucceeds",
        "TestFunctional/serial/CopySyncFile",
        "TestFunctional/serial/KubeContext",
        "TestFunctional/serial/CacheCmd/cache/add",
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc",
        "TestFunctional/serial/CacheCmd/cache/list",
        "TestStartStop/group/old-docker",
        "TestStartStop/group/crio",
        "TestFunctional/parallel/ConfigCmd",
        "TestFunctional/parallel/ProfileCmd",
        "TestFunctional/parallel/AddonsCmd",
        "TestFunctional/parallel/SSHCmd",
        "TestFunctional/parallel/FileSync",
        "TestFunctional/parallel/UpdateContextCmd"
    ],
    "SkippedTests": [
        "TestHyperKitDriverInstallOrUpdate",
        "TestChangeNoneUser"
    ],
    "Durations": {
        "TestAddons": 114.67,
        "TestDownloadOnly/group/DeleteAll": 0.05,
        "TestDownloadOnly/group/DeleteAlwaysSucceeds": 0.04,
        "TestDownloadOnly/group/ExpectedDefaultDriver": 0.04,
        "TestDownloadOnly/group/v1.11.10": 41.41,
        "TestDownloadOnly/group/v1.17.0": 35.22,
        "TestDownloadOnly/group/v1.17.0#01": 2.57,
        "TestFunctional/parallel/AddonManager": 600.01,
        "TestFunctional/parallel/AddonsCmd": 1.26,
        "TestFunctional/parallel/ComponentHealth": 0.13,
        "TestFunctional/parallel/ConfigCmd": 0.46,
        "TestFunctional/parallel/DNS": 0.07,
        "TestFunctional/parallel/DashboardCmd": 300.35,
        "TestFunctional/parallel/FileSync": 0.32,
        "TestFunctional/parallel/LogsCmd": 3.16,
        "TestFunctional/parallel/MountCmd": 3.82,
        "TestFunctional/parallel/MySQL": 0.41,
        "TestFunctional/parallel/PersistentVolumeClaim": 240.01,
        "TestFunctional/parallel/ProfileCmd": 0.52,
        "TestFunctional/parallel/SSHCmd": 0.22,
        "TestFunctional/parallel/ServiceCmd": 600.24,
        "TestFunctional/parallel/StatusCmd": 2.55,
        "TestFunctional/parallel/TunnelCmd": 0.63,
        "TestFunctional/parallel/UpdateContextCmd": 0.14,
        "TestFunctional/serial/CacheCmd/cache/add": 4.62,
        "TestFunctional/serial/CacheCmd/cache/cache_reload": 5.93,
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc": 0.05,
        "TestFunctional/serial/CacheCmd/cache/list": 0.05,
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node": 2.22,
        "TestFunctional/serial/CopySyncFile": 0,
        "TestFunctional/serial/KubeContext": 0.06,
        "TestFunctional/serial/KubectlGetPods": 0.65,
        "TestFunctional/serial/StartWithProxy": 103.99,
        "TestGvisorAddon": 183.78,
        "TestOffline/group/containerd": 319.2,
        "TestOffline/group/crio": 384.19,
        "TestOffline/group/docker": 277.48,
        "TestStartStop/group/containerd": 360.81,
        "TestStartStop/group/crio": 820.99,
        "TestStartStop/group/newest-cni": 426.41,
        "TestStartStop/group/old-docker": 549.74,
        "TestVersionUpgrade": 475.6
    },
    "TotalDuration": 0.12,
    "GopoghVersion": "v0.17.0",
    "GopoghBuild": "6937f8d5ccc2cf2987ca40306c1732c024918bb4",
    "Detail": {
        "Name": "KVM Linux",
        "Details": "1234567890",
        "PR": "1313",
        "RepoName": "github.com/kubernetes/minikube/"
    }
}
```


## Before: 
```
$ TEST_PR_NUMBER=1313
TEST_NAME="KVM Linux"
GITHUB_REPOSITORY="github.com/kubernetes/minikube/"
GITHUB_SHA=1234567890
./out/gopogh -in ./testdata/minikube-logs.json -out_html ./testout.html -out_summary ./your-test
-summary.json -name "${TEST_NAME}" -pr "${TEST_PR_NUMBER}" -repo "${GITHUB_REPOSITORY}"  -detail
s "${GITHUB_SHA}" 
{
    "NumberOfTests": 44,
    "NumberOfFail": 23,
    "NumberOfPass": 19,
    "NumberOfSkip": 2,
    "FailedTests": [
        "TestOffline/group/docker",
        "TestOffline/group/crio",
        "TestOffline/group/containerd",
        "TestAddons",
        "TestFunctional/serial/StartWithProxy",
        "TestFunctional/serial/KubectlGetPods",
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node",
        "TestFunctional/serial/CacheCmd/cache/cache_reload",
        "TestGvisorAddon",
        "TestVersionUpgrade",
        "TestStartStop/group/newest-cni",
        "TestStartStop/group/containerd",
        "TestFunctional/parallel/AddonManager",
        "TestFunctional/parallel/ComponentHealth",
        "TestFunctional/parallel/DashboardCmd",
        "TestFunctional/parallel/DNS",
        "TestFunctional/parallel/StatusCmd",
        "TestFunctional/parallel/LogsCmd",
        "TestFunctional/parallel/MountCmd",
        "TestFunctional/parallel/ServiceCmd",
        "TestFunctional/parallel/PersistentVolumeClaim",
        "TestFunctional/parallel/TunnelCmd",
        "TestFunctional/parallel/MySQL"
    ],
    "PassedTests": [
        "TestDownloadOnly/group/v1.11.10",
        "TestDownloadOnly/group/v1.17.0",
        "TestDownloadOnly/group/v1.17.0#01",
        "TestDownloadOnly/group/ExpectedDefaultDriver",
        "TestDownloadOnly/group/DeleteAll",
        "TestDownloadOnly/group/DeleteAlwaysSucceeds",
        "TestFunctional/serial/CopySyncFile",
        "TestFunctional/serial/KubeContext",
        "TestFunctional/serial/CacheCmd/cache/add",
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc",
        "TestFunctional/serial/CacheCmd/cache/list",
        "TestStartStop/group/old-docker",
        "TestStartStop/group/crio",
        "TestFunctional/parallel/ConfigCmd",
        "TestFunctional/parallel/ProfileCmd",
        "TestFunctional/parallel/AddonsCmd",
        "TestFunctional/parallel/SSHCmd",
        "TestFunctional/parallel/FileSync",
        "TestFunctional/parallel/UpdateContextCmd"
    ],
    "SkippedTests": [
        "TestHyperKitDriverInstallOrUpdate",
        "TestChangeNoneUser"
    ],
    "Durations": {
        "TestAddons": 114.67,
        "TestDownloadOnly/group/DeleteAll": 0.05,
        "TestDownloadOnly/group/DeleteAlwaysSucceeds": 0.04,
        "TestDownloadOnly/group/ExpectedDefaultDriver": 0.04,
        "TestDownloadOnly/group/v1.11.10": 41.41,
        "TestDownloadOnly/group/v1.17.0": 35.22,
        "TestDownloadOnly/group/v1.17.0#01": 2.57,
        "TestFunctional/parallel/AddonManager": 600.01,
        "TestFunctional/parallel/AddonsCmd": 1.26,
        "TestFunctional/parallel/ComponentHealth": 0.13,
        "TestFunctional/parallel/ConfigCmd": 0.46,
        "TestFunctional/parallel/DNS": 0.07,
        "TestFunctional/parallel/DashboardCmd": 300.35,
        "TestFunctional/parallel/FileSync": 0.32,
        "TestFunctional/parallel/LogsCmd": 3.16,
        "TestFunctional/parallel/MountCmd": 3.82,
        "TestFunctional/parallel/MySQL": 0.41,
        "TestFunctional/parallel/PersistentVolumeClaim": 240.01,
        "TestFunctional/parallel/ProfileCmd": 0.52,
        "TestFunctional/parallel/SSHCmd": 0.22,
        "TestFunctional/parallel/ServiceCmd": 600.24,
        "TestFunctional/parallel/StatusCmd": 2.55,
        "TestFunctional/parallel/TunnelCmd": 0.63,
        "TestFunctional/parallel/UpdateContextCmd": 0.14,
        "TestFunctional/serial/CacheCmd/cache/add": 4.62,
        "TestFunctional/serial/CacheCmd/cache/cache_reload": 5.93,
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc": 0.05,
        "TestFunctional/serial/CacheCmd/cache/list": 0.05,
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node": 2.22,
        "TestFunctional/serial/CopySyncFile": 0,
        "TestFunctional/serial/KubeContext": 0.06,
        "TestFunctional/serial/KubectlGetPods": 0.65,
        "TestFunctional/serial/StartWithProxy": 103.99,
        "TestGvisorAddon": 183.78,
        "TestOffline/group/containerd": 319.2,
        "TestOffline/group/crio": 384.19,
        "TestOffline/group/docker": 277.48,
        "TestStartStop/group/containerd": 360.81,
        "TestStartStop/group/crio": 820.99,
        "TestStartStop/group/newest-cni": 426.41,
        "TestStartStop/group/old-docker": 549.74,
        "TestVersionUpgrade": 475.6
    },
    "TotalDuration": 0.12,
    "GopoghVersion": "v0.17.0",
    "GopoghBuild": "b98c3cac308e87e62ed7d2f6659b54947c9d9007",
    "Detail": {
        "Name": "KVM Linux",
        "Details": "1234567890",
        "PR": "1313",
        "RepoName": "github.com/kubernetes/minikube/"
    }
}
```

## After: 
```
$ TEST_PR_NUMBER=1313
TEST_NAME="KVM Linux"
GITHUB_REPOSITORY="github.com/kubernetes/minikube/"
GITHUB_SHA=1234567890
./out/gopogh -in ./testdata/minikube-logs.json -out_html ./testout.html -out_summary ./your-test-summary.json -name "${TEST_NAME}" -pr "${TEST_PR_NUMBER}" -repo "${GITHUB_REPOSITORY}"  -details "${GITHUB_SHA}" 
{
    "NumberOfTests": 44,
    "NumberOfFail": 23,
    "NumberOfPass": 19,
    "NumberOfSkip": 2,
    "FailedTests": [
        "TestOffline/group/docker",
        "TestOffline/group/crio",
        "TestOffline/group/containerd",
        "TestAddons",
        "TestFunctional/serial/StartWithProxy",
        "TestFunctional/serial/KubectlGetPods",
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node",
        "TestFunctional/serial/CacheCmd/cache/cache_reload",
        "TestGvisorAddon",
        "TestVersionUpgrade",
        "TestStartStop/group/newest-cni",
        "TestStartStop/group/containerd",
        "TestFunctional/parallel/AddonManager",
        "TestFunctional/parallel/ComponentHealth",
        "TestFunctional/parallel/DashboardCmd",
        "TestFunctional/parallel/DNS",
        "TestFunctional/parallel/StatusCmd",
        "TestFunctional/parallel/LogsCmd",
        "TestFunctional/parallel/MountCmd",
        "TestFunctional/parallel/ServiceCmd",
        "TestFunctional/parallel/PersistentVolumeClaim",
        "TestFunctional/parallel/TunnelCmd",
        "TestFunctional/parallel/MySQL"
    ],
    "PassedTests": [
        "TestDownloadOnly/group/v1.11.10",
        "TestDownloadOnly/group/v1.17.0",
        "TestDownloadOnly/group/v1.17.0#01",
        "TestDownloadOnly/group/ExpectedDefaultDriver",
        "TestDownloadOnly/group/DeleteAll",
        "TestDownloadOnly/group/DeleteAlwaysSucceeds",
        "TestFunctional/serial/CopySyncFile",
        "TestFunctional/serial/KubeContext",
        "TestFunctional/serial/CacheCmd/cache/add",
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc",
        "TestFunctional/serial/CacheCmd/cache/list",
        "TestStartStop/group/old-docker",
        "TestStartStop/group/crio",
        "TestFunctional/parallel/ConfigCmd",
        "TestFunctional/parallel/ProfileCmd",
        "TestFunctional/parallel/AddonsCmd",
        "TestFunctional/parallel/SSHCmd",
        "TestFunctional/parallel/FileSync",
        "TestFunctional/parallel/UpdateContextCmd"
    ],
    "SkippedTests": [
        "TestHyperKitDriverInstallOrUpdate",
        "TestChangeNoneUser"
    ],
    "Durations": {
        "TestAddons": 114.67,
        "TestDownloadOnly/group/DeleteAll": 0.05,
        "TestDownloadOnly/group/DeleteAlwaysSucceeds": 0.04,
        "TestDownloadOnly/group/ExpectedDefaultDriver": 0.04,
        "TestDownloadOnly/group/v1.11.10": 41.41,
        "TestDownloadOnly/group/v1.17.0": 35.22,
        "TestDownloadOnly/group/v1.17.0#01": 2.57,
        "TestFunctional/parallel/AddonManager": 600.01,
        "TestFunctional/parallel/AddonsCmd": 1.26,
        "TestFunctional/parallel/ComponentHealth": 0.13,
        "TestFunctional/parallel/ConfigCmd": 0.46,
        "TestFunctional/parallel/DNS": 0.07,
        "TestFunctional/parallel/DashboardCmd": 300.35,
        "TestFunctional/parallel/FileSync": 0.32,
        "TestFunctional/parallel/LogsCmd": 3.16,
        "TestFunctional/parallel/MountCmd": 3.82,
        "TestFunctional/parallel/MySQL": 0.41,
        "TestFunctional/parallel/PersistentVolumeClaim": 240.01,
        "TestFunctional/parallel/ProfileCmd": 0.52,
        "TestFunctional/parallel/SSHCmd": 0.22,
        "TestFunctional/parallel/ServiceCmd": 600.24,
        "TestFunctional/parallel/StatusCmd": 2.55,
        "TestFunctional/parallel/TunnelCmd": 0.63,
        "TestFunctional/parallel/UpdateContextCmd": 0.14,
        "TestFunctional/serial/CacheCmd/cache/add": 4.62,
        "TestFunctional/serial/CacheCmd/cache/cache_reload": 5.93,
        "TestFunctional/serial/CacheCmd/cache/delete_busybox:1.28.4-glibc": 0.05,
        "TestFunctional/serial/CacheCmd/cache/list": 0.05,
        "TestFunctional/serial/CacheCmd/cache/verify_cache_inside_node": 2.22,
        "TestFunctional/serial/CopySyncFile": 0,
        "TestFunctional/serial/KubeContext": 0.06,
        "TestFunctional/serial/KubectlGetPods": 0.65,
        "TestFunctional/serial/StartWithProxy": 103.99,
        "TestGvisorAddon": 183.78,
        "TestOffline/group/containerd": 319.2,
        "TestOffline/group/crio": 384.19,
        "TestOffline/group/docker": 277.48,
        "TestStartStop/group/containerd": 360.81,
        "TestStartStop/group/crio": 820.99,
        "TestStartStop/group/newest-cni": 426.41,
        "TestStartStop/group/old-docker": 549.74,
        "TestVersionUpgrade": 475.6
    },
    "TotalDuration": 0.12,
    "GopoghVersion": "v0.17.0",
    "GopoghBuild": "6937f8d5ccc2cf2987ca40306c1732c024918bb4",
    "Detail": {
        "Name": "KVM Linux",
        "Details": "1234567890",
        "PR": "1313",
        "RepoName": "github.com/kubernetes/minikube/"
    }
}
```
