### PR TITLE
modify concurrency and timeout duration for lint github action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --enable gofmt,goimports,gocritic,revive,gocyclo,misspell,nakedret,stylecheck,unconvert,unparam,dogsled
+          args: --enable gofmt,goimports,gocritic,revive,gocyclo,misspell,nakedret,stylecheck,unconvert,unparam,dogsled --timeout 5m --concurrency 4
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: false


### PR DESCRIPTION
Modifies the call to golangci-lint with --timeout set to 5m and --concurrency set to 4 in order to help mitigate flakey lint github action