### PR TITLE
CI: Update release Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.1'
+          go-version: '1.20.6'
           stable: true
         id: go
       - name: Cross Platform Build


### PR DESCRIPTION
The current version of gopogh requires Go 1.18+ to build, updating to Go 1.20.6

Failed release job: https://github.com/medyagh/gopogh/actions/runs/5730420050/job/15529158198