### PR TITLE
feat: support showing growth within 3 or 7 days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ testdata/docker-test/testout.json
 testdata/docker-test/testout.html
 ./gopogh
 cmd/gopogh-server/gopogh-server
+.vscode

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -34,7 +34,7 @@ type Datab interface {
 
 	GetEnvCharts(string, int) (map[string]interface{}, error)
 
-	GetOverview() (map[string]interface{}, error)
+	GetOverview(dataRange int) (map[string]interface{}, error)
 
 	GetTestCharts(string, string) (map[string]interface{}, error)
 }

--- a/pkg/db/postgres.go
+++ b/pkg/db/postgres.go
@@ -424,7 +424,8 @@ func (m *Postgres) GetEnvCharts(env string, testsInTop int) (map[string]interfac
 }
 
 // GetOverview writes the overview charts to a map with the keys summaryAvgFail and summaryTable
-func (m *Postgres) GetOverview() (map[string]interface{}, error) {
+func (m *Postgres) GetOverview(dateRange int) (map[string]interface{}, error) {
+	// dateRange is the number of days to use to look for "flaky-est" envs.
 	start := time.Now()
 	// Filters out old data and calculates the average number of failures and average duration per day per environment
 	sqlQuery := `
@@ -441,9 +442,6 @@ func (m *Postgres) GetOverview() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("failed to execute SQL query for summary chart: %v", err)
 	}
 	log.Printf("\nduration metric: took %f seconds to execute SQL query for summary duration and failure charts since start of handler", time.Since(start).Seconds())
-
-	// Number of days to use to look for "flaky-est" envs.
-	const dateRange = 15
 
 	// Filters out data from prior to 90 days
 	// Then computes average number of fails for each environment for each time frame

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -133,6 +133,6 @@ func (m *sqlite) GetTestCharts(_ string, _ string) (map[string]interface{}, erro
 
 // GetOverview writes the overview charts to a map with the keys summaryAvgFail and summaryTable
 // This is not yet supported for sqlite
-func (m *sqlite) GetOverview() (map[string]interface{}, error) {
+func (m *sqlite) GetOverview(int) (map[string]interface{}, error) {
 	return nil, nil
 }

--- a/pkg/handler/flake_chart.html
+++ b/pkg/handler/flake_chart.html
@@ -38,8 +38,38 @@ function parseUrlQuery(query) {
       return [unescape(keyValue[0]), unescape(keyValue[1])];
   }));
 }
+function createDateRangeSelectForFailTable(table){
+  let tableCapturedByLambda = table
+  let dateSelect = document.createElement("select")
+  dateSelect.innerHTML = "<option value=3>3</option> <option value=7>7</option>  <option value=15 selected='selected'>15</option>"
+  dateSelect.addEventListener('click', async function (event) {
+    // stop the onClick event from propagation to its parent 
+    event.stopPropagation();
+  }, false);  
+  dateSelect.addEventListener("change", async function(event){
+    // when a new date range is selected
+    // fetch new data and replace old table with new table
+    const parent = tableCapturedByLambda.parentElement
+    const dateRange = dateSelect.options[dateSelect.selectedIndex].value
+    const response = await fetch("/summary?date_range="+dateRange);
+      if (!response.ok) {
+          throw new Error('Network response was not ok');
+      }
+      const data = await response.json();
+      let newTable = createRecentNumberOfFailTable(data.summaryTable, dateRange)
+      parent.replaceChild(newTable, tableCapturedByLambda)
+      tableCapturedByLambda = newTable
+  })
+  let wrapper = document.createElement("div")
+  wrapper.style.width = "100%"
+  wrapper.style.textAlign = "center"
+  wrapper.innerHTML = "Show Growth within "
+  wrapper.insertAdjacentElement("beforeend", dateSelect)
+  wrapper.insertAdjacentHTML("beforeend", " days")
 
-function createRecentNumberOfFailTable(summaryTable) {
+  return wrapper
+}
+function createRecentNumberOfFailTable(summaryTable, dateRange=15) {
   const createCell = (elementType, text) => {
       const element = document.createElement(elementType);
       element.innerHTML = text;
@@ -50,7 +80,7 @@ function createRecentNumberOfFailTable(summaryTable) {
   tableHeaderRow.appendChild(createCell("th", "Rank"));
   tableHeaderRow.appendChild(createCell("th", "Env Name")).style.textAlign = "left";
   tableHeaderRow.appendChild(createCell("th", "Recent Number of Fails"));
-  tableHeaderRow.appendChild(createCell("th", "Growth (since last 15 days)"));
+  tableHeaderRow.appendChild(createCell("th", `Growth (since last ${dateRange} days)`));
   table.appendChild(tableHeaderRow);
   const tableBody = document.createElement("tbody");
   for (let i = 0; i < summaryTable.length; i++) {
@@ -521,8 +551,10 @@ function displaySummaryChart(data) {
   const durationChart = new google.visualization.LineChart(summaryDurContainer);
   durationChart.draw(durChart, durOptions);
 
-
-  chartsContainer.appendChild(createRecentNumberOfFailTable(data.summaryTable))
+  const table=createRecentNumberOfFailTable(data.summaryTable)
+  const select=createDateRangeSelectForFailTable(table)
+  chartsContainer.appendChild(select)
+  chartsContainer.appendChild(table)
 }
 
 function displayEnvironmentChart(data, query) {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -120,8 +120,13 @@ func (m *DB) ServeEnvCharts(w http.ResponseWriter, r *http.Request) {
 }
 
 // ServeOverview writes the overview chart for all of the environments to a JSON HTTP response
-func (m *DB) ServeOverview(w http.ResponseWriter, _ *http.Request) {
-	data, err := m.Database.GetOverview()
+func (m *DB) ServeOverview(w http.ResponseWriter, r *http.Request) {
+	dateRange, err := strconv.Atoi(r.URL.Query().Get("date_range"))
+	if err != nil {
+		dateRange = 15
+	}
+
+	data, err := m.Database.GetOverview(dateRange)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
feat: support show growth within 7 days

Before:
Just a table which only support growth for 15 days
![Screenshot 2023-10-02 at 16 22 09](https://github.com/medyagh/gopogh/assets/46831212/6fa5feec-a6e3-47cb-afeb-7135f475f936)

After:

You can choose how many days you want to measure the growth
![Screenshot 2023-10-21 at 17 03 16](https://github.com/medyagh/gopogh/assets/46831212/ee7f3b20-22b0-475d-a6c7-02ca6a6d5566)

And if you select another choice, the table will be updated according to the new data returned by backend

![Screenshot 2023-10-02 at 16 20 16](https://github.com/medyagh/gopogh/assets/46831212/bb4ab0da-682f-4351-a8e8-b5e5c47ea234)


API change: /summary API now can accept an GET parameter 'date_range'. if this parameter is not presented, old default 15 will used

Besides, a small questions: how do you format the html file? @medyagh 

