### PR TITLE
Make postgres the owner of new materialized view

### DIFF
--- a/pkg/db/postgres.go
+++ b/pkg/db/postgres.go
@@ -153,9 +153,11 @@ func (m *Postgres) createMaterializedView(env string, viewName string) error {
 	if _, err := m.db.Exec(createView); err != nil {
 		return err
 	}
-	// refresh the materialzed view
-	refreshView := fmt.Sprintf("REFRESH MATERIALIZED VIEW %s ;", viewName)
-	if _, err := m.db.Exec(refreshView); err != nil {
+
+	// if we add a new test environment the service account will be the owner of the newly created materalized view above
+	// but we require postgres to be the owner for the cron that refreshes the materialized view to run
+	alterOwner := fmt.Sprintf("ALTER MATERIALIZED VIEW %s OWNER TO postgres;", viewName)
+	if _, err := m.db.Exec(alterOwner); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
As the comment in the code says, we ran into an issue where a new environment was added, this resulted in a new materialized view to be created, but the service account was the owner of the view. We have a cron job under the postgres user that refreshes the materialized views twice a day, but only the owner can refresh the views. Because the owner of the new materialized view was the service account the cron failed to refresh the view and resulted in none of the views being updated.

This ensures that postgres is the owner of all the views, and will prevent this issue from happening in the future.