### PR TITLE
CI: Dynamically update version from git tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Cross Platform Build
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           cache: false
       - uses: actions/checkout@v4
       - name: golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Test
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine
+FROM golang:1.21-alpine
 WORKDIR /src/
 COPY ./ ./
 RUN apk -U add make git

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,14 +1,15 @@
 FROM golang:1.21 AS builder
 WORKDIR /app
+COPY Makefile ./
 COPY go.mod go.sum ./
 RUN go mod download
-COPY cmd/gopogh-server/main.go ./
+COPY cmd/gopogh-server/main.go ./cmd/gopogh-server/main.go
 COPY pkg ./pkg
-RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o /gopogh-server
+RUN make server
 
 FROM alpine:3
 WORKDIR /
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /gopogh-server /gopogh-server
+COPY --from=builder /app/out/gopogh-server /gopogh-server
 EXPOSE 8080
 CMD ["/gopogh-server", "-use_cloudsql", "-use_iam_auth"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ out/gopogh:
 
 .PHONY: out/gopogh-darwin-arm64
 out/gopogh-darwin-arm64:
-	GOOS=darwin GOARCH=arm6 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
+	GOOS=darwin GOARCH=arm64 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
 
 .PHONY: out/gopogh-darwin-amd64
 out/gopogh-darwin-amd64:
@@ -52,7 +52,7 @@ out/gopogh-server:
 
 .PHONY: out/gopogh-server-darwin-arm64
 out/gopogh-server-darwin-arm64:
-        GOOS=darwin GOARCH=arm6 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+        GOOS=darwin GOARCH=arm64 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
 
 .PHONY: out/gopogh-server-darwin-amd64
 out/gopogh-server-darwin-amd64:

--- a/Makefile
+++ b/Makefile
@@ -2,35 +2,77 @@ BINARY=/out/gopogh
 GIT_TAG=`git describe --tags`
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 BUILD ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
-LDFLAGS :=-X github.com/medyagh/gopogh/pkg/report.Build=${BUILD}
-VERSION := v0.17.0
+LDFLAGS :=-X github.com/medyagh/gopogh/pkg/report.Build=${BUILD} -X github.com/medyagh/gopogh/pkg/report.version=${GIT_TAG}
 MK_REPO=github.com/kubernetes/minikube/
 DUMMY_COMMIT_NUM=0c07e808219403a7241ee5a0fc6a85a897594339
 DUMMY_COMMIT2_NUM=0168d63fc8c165681b1cad1801eadd6bbe2c8a5c
+
+BUILD_GOPOGH := CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -a -o
+GOPOGH_CMD := github.com/medyagh/gopogh/cmd/gopogh
 
 .PHONY: build
 build: out/gopogh
 
 .PHONY: out/gopogh
-out/gopogh: 
-	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+out/gopogh:
+	$(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
 
+.PHONY: out/gopogh-darwin-arm64
 out/gopogh-darwin-arm64:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+	GOOS=darwin GOARCH=arm6 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
 
+.PHONY: out/gopogh-darwin-amd64
 out/gopogh-darwin-amd64:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+	GOOS=darwin GOARCH=amd64 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
 
-out/gopogh-linux-amd64: 
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+.PHONY: out/gopogh-linux-amd64
+out/gopogh-linux-amd64:
+	GOOS=linux GOARCH=amd64 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
 
-out/gopogh-linux-arm: 
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+.PHONY: out/gopogh-linux-arm
+out/gopogh-linux-arm:
+	GOOS=linux GOARCH=arm $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
 
+.PHONY: out/gopogh-linux-arm64
 out/gopogh-linux-arm64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
-out/gopogh.exe: 
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64  go build -ldflags="$(LDFLAGS)" -a -o $@ github.com/medyagh/gopogh/cmd/gopogh
+	GOOS=linux GOARCH=arm64 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
+
+.PHONY: out/gopogh.exe
+out/gopogh.exe:
+	GOOS=windows GOARCH=amd64 $(BUILD_GOPOGH) $@ $(GOPOGH_CMD)
+
+GOPOGH_SERVER_CMD := github.com/medyagh/gopogh/cmd/gopogh-server
+
+.PHONY: server
+server: out/gopogh-server
+
+.PHONY: out/gopogh-server
+out/gopogh-server:
+	$(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+
+.PHONY: out/gopogh-server-darwin-arm64
+out/gopogh-server-darwin-arm64:
+        GOOS=darwin GOARCH=arm6 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+
+.PHONY: out/gopogh-server-darwin-amd64
+out/gopogh-server-darwin-amd64:
+        GOOS=darwin GOARCH=amd64 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+
+.PHONY: out/gopogh-server-linux-amd64
+out/gopogh-server-linux-amd64:
+        GOOS=linux GOARCH=amd64 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+
+.PHONY: out/gopogh-server-linux-arm
+out/gopogh-server-linux-arm:
+        GOOS=linux GOARCH=arm $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+
+.PHONY: out/gopogh-server-linux-arm64
+out/gopogh-server-linux-arm64:
+        GOOS=linux GOARCH=arm64 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
+
+.PHONY: out/gopogh-server.exe
+out/gopogh-server.exe:
+        GOOS=windows GOARCH=amd64 $(BUILD_GOPOGH) $@ $(GOPOGH_SERVER_CMD)
 
 # gopogh requires a json input, uses go tool test2json to convert to json
 generate_json:
@@ -87,11 +129,6 @@ test-in-docker:
 .PHONY: azure_blob_connection_string
 azure_blob_connection_string: ## set this env export AZURE_STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -n $AZ_STORAGE -g $AZ_RG --query connectionString -o tsv)
 	az storage account show-connection-string -n ${AZ_STORAGE} -g ${AZ_RG} --query connectionString -o tsv
-
-
-.PHONY: bump-version
-bump-version:
-	sed -i 's/var Version = \".*\"/var Version = \"$(VERSION)\"/' pkg/report/types.go
 
 load-fake-db:
 	./hack/fakedb.sh $(RECORD_PATH)

--- a/cmd/gopogh/main.go
+++ b/cmd/gopogh/main.go
@@ -35,7 +35,7 @@ var (
 func main() {
 	flag.Parse()
 	if *version {
-		fmt.Printf("Version %s Build %s", report.Version, report.Build)
+		fmt.Printf("Version %s Build %s", report.Version(), report.Build)
 	}
 
 	if *inPath == "" {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -152,7 +152,7 @@ func (m *DB) ServeOverview(w http.ResponseWriter, r *http.Request) {
 // ServeGopoghVersion writes the gopogh version to a json response
 func ServeGopoghVersion(w http.ResponseWriter, _ *http.Request) {
 	data := map[string]interface{}{
-		"version": report.Version,
+		"version": report.Version(),
 	}
 	jsonData, err := json.Marshal(data)
 	if err != nil {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -70,7 +70,7 @@ func (c DisplayContent) ShortSummary() ([]byte, error) {
 	ss.NumberOfTests = ss.NumberOfFail + ss.NumberOfPass + ss.NumberOfSkip
 	ss.TotalDuration = c.TotalDuration
 	ss.Detail = c.Detail
-	ss.GopoghVersion = Version
+	ss.GopoghVersion = Version()
 	ss.GopoghBuild = Build
 	return json.MarshalIndent(ss, "", "    ")
 }
@@ -190,7 +190,7 @@ func Generate(report models.ReportDetail, groups []models.TestGroup) (DisplayCon
 		Results:       rs,
 		TotalTests:    testsNumber,
 		TotalDuration: math.Round(endTime.Sub(startTime).Seconds()*100) / 100,
-		BuildVersion:  Version + "_" + Build,
+		BuildVersion:  Version() + "_" + Build,
 		CreatedOn:     time.Now(),
 		Detail:        report,
 		TestTime:      startTime,

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -1,7 +1,7 @@
 package report
 
-// Version is gopogh version
-var Version = "v0.23.0"
+// version is a private field and should be set when compiling with --ldflags="-X github.com/medyagh/gopogh/pkg/report.version=vX.Y.Z"
+var version = "v0.0.0-unset"
 
 // Build includes commit sha date
 var Build string
@@ -13,3 +13,8 @@ const (
 )
 
 var resultTypes = [3]string{pass, fail, skip}
+
+// Version returns the version of gopogh
+func Version() string {
+	return version
+}


### PR DESCRIPTION
- We had a version in both `Makefile` & `pkg/report/types.go` but both were not being updated and would result in gopogh reporting the incorrect version number
- Updated the version to be set via `-ldflags` where the value is generated via `git describe --tags` so it's always up to date
- Removed `bump-version` Makefile target as it's no longer needed
- Updated Makefile targets to use variables to reduce duplication
- Added Makefile targets for gopogh-server
- Updated gopogh-server Dockerfile to user newly created Makefile targets
- Bumped gopopgh Dockerfile go version to 1.21