### PR TITLE
Update go.mod version from 1.20 to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/medyagh/gopogh
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0


### PR DESCRIPTION
One of our go imports uses the `slices` package, so if you try building gopogh with Go 1.20 you get an error:
```
slices: package slices is not in GOROOT (/home/dependabot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.20.10.linux-amd64/src/slices)
```
So updating minimum required Go version to 1.21