### PR TITLE
feat: support showing test duration and its growth in summary

### DIFF
--- a/pkg/handler/flake_chart.html
+++ b/pkg/handler/flake_chart.html
@@ -81,19 +81,26 @@ function createRecentNumberOfFailTable(summaryTable, dateRange=15) {
   tableHeaderRow.appendChild(createCell("th", "Env Name")).style.textAlign = "left";
   tableHeaderRow.appendChild(createCell("th", "Recent Number of Fails"));
   tableHeaderRow.appendChild(createCell("th", `Growth (since last ${dateRange} days)`));
+  tableHeaderRow.appendChild(createCell("th", `Test Duration`));
+  tableHeaderRow.appendChild(createCell("th", `Test Duration Growth`));
   table.appendChild(tableHeaderRow);
   const tableBody = document.createElement("tbody");
   for (let i = 0; i < summaryTable.length; i++) {
       const {
           envName,
           recentNumberOfFail,
-          growth
+          growth,
+          testDuration,
+          //previousTestDuration,
+          testDurationGrowth
       } = summaryTable[i];
       const row = document.createElement("tr");
       row.appendChild(createCell("td", "" + (i + 1))).style.textAlign = "center";
       row.appendChild(createCell("td", `<a href="${window.location.pathname}?env=${envName}">${envName}</a>`));
       row.appendChild(createCell("td", recentNumberOfFail)).style.textAlign = "right";
-      row.appendChild(createCell("td", `<span style="color: ${growth === 0 ? "black" : (growth > 0 ? "red" : "green")}">${growth > 0 ? '+' + growth : growth}</span>`));
+      row.appendChild(createCell("td", `<span style="color: ${growth === 0 ? "black" : (growth > 0 ? "red" : "green")}">${growth > 0 ? '+' + growth : growth}</span>`)).style.textAlign = "right";
+      row.appendChild(createCell("td", testDuration)).style.textAlign = "right";
+      row.appendChild(createCell("td", `<span style="color: ${testDurationGrowth === 0 ? "black" : (testDurationGrowth > 0 ? "red" : "green")}">${testDurationGrowth > 0 ? '+' + testDurationGrowth : testDurationGrowth}</span>`)).style.textAlign = "right";
       tableBody.appendChild(row);
   }
   table.appendChild(tableBody);

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -98,7 +98,10 @@ type DBSummaryAvgFail struct {
 
 // DBSummaryTable represents a row in the summary number of fail table
 type DBSummaryTable struct {
-	EnvName            string  `json:"envName"`
-	RecentNumberOfFail float32 `json:"recentNumberOfFail"`
-	Growth             float32 `json:"growth"`
+	EnvName              string  `json:"envName"`
+	RecentNumberOfFail   float32 `json:"recentNumberOfFail"`
+	Growth               float32 `json:"growth"`
+	TestDuration         float32 `json:"testDuration"`
+	PreviousTestDuration float32 `json:"previousTestDuration"`
+	TestDurationGrowth   float32 `json:"testDurationGrowth"`
 }


### PR DESCRIPTION
feat: support showing test duration and its growth in summary

FIX #127 

Before (screenshot from #127) 

<img width="917" alt="320163102-8e51f3a9-32e0-4ec8-8b81-ea3e9a045c86" src="https://github.com/medyagh/gopogh/assets/46831212/180e4399-5468-49b4-ba1c-787f9645404f">

After:

![Screenshot 2024-04-21 at 21 00 30](https://github.com/medyagh/gopogh/assets/46831212/57bf860f-9afe-422c-a878-46fe3071f92d)
*corner case: When there is no data available, the test duration and the its growth will be shown as 0*
