### PR TITLE
Fix version output

### DIFF
--- a/cmd/gopogh/main.go
+++ b/cmd/gopogh/main.go
@@ -35,7 +35,8 @@ var (
 func main() {
 	flag.Parse()
 	if *version {
-		fmt.Printf("Version %s Build %s", report.Version(), report.Build)
+		fmt.Printf("Version %s Build %s\n", report.Version(), report.Build)
+		return
 	}
 
 	if *inPath == "" {


### PR DESCRIPTION
**Before:**
```
$ gopogh --version
Version v0.27.0 Build b59717b23b9dc7b14537b53818a9761ef989e15ePlease provide path to JSON input file using -in
```

**After:**
```
$ gopogh --version
Version v0.27.0 Build b59717b23b9dc7b14537b53818a9761ef989e15e
```

Added missing return and newline