### PR TITLE
add number tests ran in the summary table

### DIFF
--- a/pkg/handler/flake_chart.html
+++ b/pkg/handler/flake_chart.html
@@ -132,13 +132,15 @@ function createRecentFlakePercentageTable(recentFlakePercentTable, query) {
   for (let i = 0; i < recentFlakePercentTable.length; i++) {
       const {
           testName,
+	      failedTestNum,
+          totalTestNum,
           recentFlakePercentage,
           growthRate
       } = recentFlakePercentTable[i];
       const row = document.createElement("tr");
       row.appendChild(createCell("td", "" + (i + 1))).style.textAlign = "center";
       row.appendChild(createCell("td", `<a href="${window.location.pathname}?env=${query.env}&test=${testName}">${testName}</a>`));
-      row.appendChild(createCell("td", recentFlakePercentage + "%")).style.textAlign = "right";
+      row.appendChild(createCell("td", recentFlakePercentage + "%(" + failedTestNum + "/" + totalTestNum + ")")).style.textAlign = "right";
       row.appendChild(createCell("td", `<span style="color: ${growthRate === 0 ? "black" : (growthRate > 0 ? "red" : "green")}">${growthRate > 0 ? '+' + growthRate : growthRate}%</span>`));
       tableBody.appendChild(row);
   }

--- a/pkg/handler/flake_chart.html
+++ b/pkg/handler/flake_chart.html
@@ -140,7 +140,7 @@ function createRecentFlakePercentageTable(recentFlakePercentTable, query) {
       const row = document.createElement("tr");
       row.appendChild(createCell("td", "" + (i + 1))).style.textAlign = "center";
       row.appendChild(createCell("td", `<a href="${window.location.pathname}?env=${query.env}&test=${testName}">${testName}</a>`));
-      row.appendChild(createCell("td", recentFlakePercentage + "%(" + failedTestNum + "/" + totalTestNum + ")")).style.textAlign = "right";
+      row.appendChild(createCell("td", recentFlakePercentage + "% (" + failedTestNum + "/" + totalTestNum + ")")).style.textAlign = "right";
       row.appendChild(createCell("td", `<span style="color: ${growthRate === 0 ? "black" : (growthRate > 0 ? "red" : "green")}">${growthRate > 0 ? '+' + growthRate : growthRate}%</span>`));
       tableBody.appendChild(row);
   }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -61,6 +61,8 @@ type DBFlakeRow struct {
 	TestName              string  `json:"testName"`
 	RecentFlakePercentage float32 `json:"recentFlakePercentage"`
 	GrowthRate            float32 `json:"growthRate"`
+	FailedTestNum         float32 `json:"failedTestNum"`
+	TotalTestNum          float32 `json:"totalTestNum"`
 }
 
 // DBFlakeBy represents a "row" in the flake rate by _ of top 10 of recent test flakiness charts


### PR DESCRIPTION
FIX #154 
Before:
![](https://private-user-images.githubusercontent.com/4564227/349281195-71e16623-0def-4c4f-8901-6f109e0ef708.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjY5NTQ1NDIsIm5iZiI6MTcyNjk1NDI0MiwicGF0aCI6Ii80NTY0MjI3LzM0OTI4MTE5NS03MWUxNjYyMy0wZGVmLTRjNGYtODkwMS02ZjEwOWUwZWY3MDgucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDkyMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA5MjFUMjEzMDQyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NTBmMWE4NTBiMmYzZDRkMjZmNDIyNTkwNmIzOTg1ZTVjN2VhN2NmYWM3ZWFjNDIzOTkxNDY0ZWEzODcwMTg4NiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.x_sU5HTq1dDL4N2L0ojEOV1bzK5Vu_vbhbMys40qWM8)
After: 
![Screenshot 2024-09-21 at 23 29 25](https://github.com/user-attachments/assets/bd914c13-a0f9-413f-b256-b8f6003fd501)
